### PR TITLE
Update queryBuilder with result of custom repository method

### DIFF
--- a/Search/Reindex/Provider/DoctrineOrmProvider.php
+++ b/Search/Reindex/Provider/DoctrineOrmProvider.php
@@ -94,7 +94,7 @@ class DoctrineOrmProvider implements ReindexProviderInterface
 
                 return $this->sliceEntities($offset, $maxResults);
             }
-            
+
             $queryBuilder = $result;
         }
 

--- a/Search/Reindex/Provider/DoctrineOrmProvider.php
+++ b/Search/Reindex/Provider/DoctrineOrmProvider.php
@@ -94,6 +94,8 @@ class DoctrineOrmProvider implements ReindexProviderInterface
 
                 return $this->sliceEntities($offset, $maxResults);
             }
+            
+            $queryBuilder = $result;
         }
 
         $queryBuilder->setFirstResult($offset);


### PR DESCRIPTION
When using a custom repository method, the result of the method is not currently used when returning a QueryBuilder instance, which causes all records to be indexed instead of only the filtered results.